### PR TITLE
Enabling Django 4 support

### DIFF
--- a/djangocms_column/__init__.py
+++ b/djangocms_column/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "2.11.2"  # version bump; deviates from divio/master which is at 1.11.0
+__version__ = "2.12.0"  # version bump; deviates from divio/master which is at 1.11.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from djangocms_column import __version__
 
 INSTALL_REQUIRES = [
     'django-cms>=3.4.5',
-    'Django>=1.11,<3.3',
+    'Django>=1.11,<4.3',
     'six>=1.9.0',
 ]
 


### PR DESCRIPTION
Lossening the requirements in setup.py and bumping the package version.